### PR TITLE
Fix deliver_sm decoding

### DIFF
--- a/Smpp/Common.cs
+++ b/Smpp/Common.cs
@@ -1047,5 +1047,16 @@ namespace Smpp
 
             return builder.ToString();
         }
+
+        public static string HexToString(string hex, Encoding encoding)
+        {
+            var bytes = new byte[hex.Length / 2];
+            for (var i = 0; i < bytes.Length; i++)
+            {
+                bytes[i] = Convert.ToByte(hex.Substring(i * 2, 2), 16);
+            }
+
+            return encoding.GetString(bytes);
+        }
     }
 }

--- a/Smpp/Connection.cs
+++ b/Smpp/Connection.cs
@@ -722,7 +722,7 @@ namespace Smpp
                     try
                     {
                         deliver_sm = new DeliverSm(pdu);
-                        deliver_sm.Is8bit = use8bit;
+                        deliver_sm.Is8bit = /*use8bit*/true;
                         deliver_sm.Decode();
                     }
                     catch (CommandLengthException)

--- a/Smpp/Connection.cs
+++ b/Smpp/Connection.cs
@@ -847,7 +847,7 @@ namespace Smpp
 
                     // Log message
                     Events.LogChannelEvent(channel_name, "Message received from " + deliver_sm.Sender + " to " + deliver_sm.Recipient, debug ? pdu : "");
-                    Events.LogNewMessageEvent(channel_name, deliver_sm_resp.MessageID, deliver_sm.Sender, deliver_sm.Recipient, deliver_sm.Body, deliver_sm.BodyFormat, deliver_sm.RegisteredDelivery);
+                    Events.LogNewMessageEvent(channel_name, deliver_sm_resp.MessageID, deliver_sm.Sender, deliver_sm.Recipient, deliver_sm.Body, deliver_sm.BodyFormat, deliver_sm.RegisteredDelivery, deliver_sm.UserMessageReference);
 
                     break;
                 case "deliver_sm_resp":

--- a/Smpp/Events/GateEvents.cs
+++ b/Smpp/Events/GateEvents.cs
@@ -16,7 +16,7 @@ namespace Smpp.Events
         public delegate void LogMessageDeliverReportEventHandler(string responseMessageId, Common.MessageStatus status);
         public event LogMessageDeliverReportEventHandler MessageDeliveryReportEvent;
 
-        public delegate void LogNewMessageEventHandler(string channelName, string messageId, string sender, string recipient, string body, string bodyFormat, int registeredDelivery);
+        public delegate void LogNewMessageEventHandler(string channelName, string messageId, string sender, string recipient, string body, string bodyFormat, int registeredDelivery, string userMessageReference);
         public event LogNewMessageEventHandler NewMessageEvent;
 
         public event EventHandler<SubmitSmEventArgs> SubmitSmReceived;
@@ -77,10 +77,11 @@ namespace Smpp.Events
         /// <param name="body"></param>
         /// <param name="bodyFormat"></param>
         /// <param name="registeredDelivery"></param>
-        public void LogNewMessageEvent(string channelName, string messageId, string sender, string recipient, string body, string bodyFormat, int registeredDelivery)
+        public void LogNewMessageEvent(string channelName, string messageId, string sender, string recipient,
+            string body, string bodyFormat, int registeredDelivery, string userMessageReference = null)
         {
             LogNewMessageEventHandler handler = NewMessageEvent;
-            if (handler != null) handler(channelName, messageId, sender, recipient, body, bodyFormat, registeredDelivery);
+            if (handler != null) handler(channelName, messageId, sender, recipient, body, bodyFormat, registeredDelivery, userMessageReference);
         }
 
         public void OnSubmitSmReceived(SubmitSmEventArgs e)

--- a/Smpp/Requests/DeliverSm.cs
+++ b/Smpp/Requests/DeliverSm.cs
@@ -287,6 +287,8 @@ namespace Smpp.Requests
             }
         }
 
+        public string UserMessageReference { get; set; }
+
         public override void Decode()
         {
             string tail = body;
@@ -321,6 +323,9 @@ namespace Smpp.Requests
             replace_if_present_flag = bt[1];
             data_coding = bt[2];
             sm_default_msg_id = bt[3];
+
+            var userMessageRefTlvValue = tail.Substring(tail.Length - 72); // 72 length of the part of umid.
+            UserMessageReference = Common.HexToString(userMessageRefTlvValue);
 
             sm_length = bt[4];
             if (sm_length != 0)

--- a/Smpp/Requests/DeliverSm.cs
+++ b/Smpp/Requests/DeliverSm.cs
@@ -352,6 +352,9 @@ namespace Smpp.Requests
                         }
                         break;
                     case 3: // Latin 1 (ISO-8859-1)
+                        body_hex = tail.Substring(0, sm_length * 2);
+                        short_message = Common.HexToString(body_hex, Encoding.UTF7);
+                        break;
                     case 1: // ASCII
                     case 0:
                         body_hex = tail.Substring(0, sm_length * 2);


### PR DESCRIPTION
- Parse Latin-1 script correctly (DCS 3).
- Interpret MO messages as 8-bits.